### PR TITLE
Pass additional options to i18n

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,11 +42,11 @@ module.exports = function (ops) {
     }
 
     return function (files, ms, done) {
-        i18n.configure({
-            defaultLocale: ops.default,
-            locales:       ops.locales,
-            directory:     ms.path(ops.directory)
-        });
+        ops["defaultLocale"] = ops.default;
+        ops["directory"] = ms.path(ops.directory);
+        delete ops["default"];
+        // passing options to i18n
+        i18n.configure( ops );
 
         for (var file in files) {
             files[file].__  = __.bind(files[file]);


### PR DESCRIPTION
I don't like i18n-node to modify my locale files. With this patch I can set the option `updateFiles` in the i18n plugin, so it's later passed to the [configuration options](https://github.com/mashpie/i18n-node#list-of-configuration-options) of [i18n-node](https://github.com/mashpie/i18n-node).

``` .js
  .use( i18n({
      default: 'en',
      locales: ['en', 'es'],
      directory: 'layouts/locales',
      updateFiles: false
  }) )
```
